### PR TITLE
Tokenize strictly by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,13 +62,29 @@ console.log(result.stdout);
 
 ## API
 
-### `tokenizeArgs(command: string): string[]`
+### `tokenizeArgs(command: string, options: Options): string[]`
 
 Parses a shell command string into an array of arguments. Properly handles:
 
 - Quoted strings (e.g., `'"./path/to/file"'`).
 - Escaped characters (e.g., `\"`).
 - Multiline commands (e.g., lines ending with `\\`).
+
+### Options
+
+- `loose`: If `true`, the tokenizer will not throw an error when closing quotes are missing. Default is `false`.
+
+#### Examples
+
+```js
+// Without loose option (default behavior)
+// This will throw an error due to the missing closing quote
+tokenizeArgs('command "arg1 arg2');
+
+// With loose option enabled
+const args = tokenizeArgs('command "arg1 arg2', { loose: true });
+// ['command', 'arg1 arg2']
+```
 
 ## License
 

--- a/src/args-tokenizer.test.ts
+++ b/src/args-tokenizer.test.ts
@@ -21,6 +21,16 @@ test("inconsistently quoted arguments", () => {
   expect(tokenizeArgs(`command "arg"um"en"t`)).toEqual(["command", "argument"]);
 });
 
+test("forgive incomplete quotes", () => {
+  expect(tokenizeArgs(`command "arg`)).toEqual(["command", "arg"]);
+});
+
+test("detects incomplete quotes in strict mode", () => {
+  expect(() => {
+    tokenizeArgs(`command "arg`, { strict: true });
+  }).toThrow("Unexpected end of string. Closing quote is missing.");
+});
+
 test("escape quotes and spaces with other quotes", () => {
   expect(tokenizeArgs(`command 'quote "' "quote '"`)).toEqual([
     "command",

--- a/src/args-tokenizer.test.ts
+++ b/src/args-tokenizer.test.ts
@@ -21,14 +21,17 @@ test("inconsistently quoted arguments", () => {
   expect(tokenizeArgs(`command "arg"um"en"t`)).toEqual(["command", "argument"]);
 });
 
-test("forgive incomplete quotes", () => {
-  expect(tokenizeArgs(`command "arg`)).toEqual(["command", "arg"]);
+test("detects incomplete quotes ", () => {
+  expect(() => {
+    tokenizeArgs(`command "arg1 "arg2" "arg3"`);
+  }).toThrow("Unexpected end of string. Closing quote is missing.");
 });
 
-test("detects incomplete quotes in strict mode", () => {
-  expect(() => {
-    tokenizeArgs(`command "arg`, { strict: true });
-  }).toThrow("Unexpected end of string. Closing quote is missing.");
+test("forgive incomplete quotes in loose mode", () => {
+  expect(tokenizeArgs(`command "arg1 "arg2" "arg3"`, { loose: true })).toEqual([
+    "command",
+    "arg1 arg2 arg3",
+  ]);
 });
 
 test("escape quotes and spaces with other quotes", () => {
@@ -47,7 +50,7 @@ test("escape quotes with backslashes", () => {
 });
 
 test("escape spaces with backslashes", () => {
-  expect(tokenizeArgs(`command space\\ "`)).toEqual(["command", "space "]);
+  expect(tokenizeArgs(`command space\\ `)).toEqual(["command", "space "]);
 });
 
 test("ignore escaped newlines outside of quotes", () => {

--- a/src/args-tokenizer.ts
+++ b/src/args-tokenizer.ts
@@ -1,7 +1,7 @@
 const spaceRegex = /\s/;
 
 type Options = {
-  strict?: boolean;
+  loose?: boolean;
 };
 
 /**
@@ -57,7 +57,10 @@ export const tokenizeArgs = (
   if (currentToken.length > 0) {
     tokens.push(currentToken);
   }
-  if (options?.strict && openningQuote) {
+  if (options?.loose) {
+    return tokens;
+  }
+  if (openningQuote) {
     throw Error("Unexpected end of string. Closing quote is missing.");
   }
   return tokens;

--- a/src/args-tokenizer.ts
+++ b/src/args-tokenizer.ts
@@ -1,9 +1,16 @@
 const spaceRegex = /\s/;
 
+type Options = {
+  strict?: boolean;
+};
+
 /**
  * Tokenize a shell string into argv array
  */
-export const tokenizeArgs = (argsString: string): string[] => {
+export const tokenizeArgs = (
+  argsString: string,
+  options?: Options,
+): string[] => {
   const tokens = [];
   let currentToken = "";
   let openningQuote: undefined | string;
@@ -49,6 +56,9 @@ export const tokenizeArgs = (argsString: string): string[] => {
   }
   if (currentToken.length > 0) {
     tokens.push(currentToken);
+  }
+  if (options?.strict && openningQuote) {
+    throw Error("Unexpected end of string. Closing quote is missing.");
   }
   return tokens;
 };


### PR DESCRIPTION
Here changed default behavior to fail when closing quote is missing.
Optionally loose flag can be enabled to parse even with missing quotes.

```js
tokenizeArgs('command \"arg')
// throws
// Unexpected end of string. Closing quote is missing.

tokenizeArgs('command \"arg', { loose: true })
// ['command', 'arg']
```