### PR TITLE
Quoted empty strings are valid arguments.

### DIFF
--- a/src/args-tokenizer.test.ts
+++ b/src/args-tokenizer.test.ts
@@ -116,3 +116,17 @@ test("empty command", () => {
   expect(tokenizeArgs(``)).toEqual([]);
   expect(tokenizeArgs(`  `)).toEqual([]);
 });
+
+test("empty quoted argument", () => {
+  expect(tokenizeArgs(`a0 "" a1`)).toEqual(["a0", "", "a1"]);
+  expect(tokenizeArgs(`a0 '' a1`)).toEqual(["a0", "", "a1"]);
+  expect(tokenizeArgs(`a0 ""''""'' a1`)).toEqual(["a0", "", "a1"]);
+  // the next test fails, when the erroneous unescaping of newlines in double quotes is fixed
+  // correct test is:
+  // expect(tokenizeArgs(`"a0" "\\\n" a1`)).toEqual(["a0", "", "a1"]);
+  expect(tokenizeArgs(`"a0" "\\\n" a1`)).toEqual(["a0", "\n", "a1"]);
+  // the next test fails, when the erroneous unescaping in single quotes is fixed
+  // correct test is:
+  // expect(tokenizeArgs(`"a0" '\\\n' a1`)).toEqual(["a0", "\\\n", "a1"]);
+  expect(tokenizeArgs(`"a0" '\\\n' a1`)).toEqual(["a0", "\n", "a1"]);
+});

--- a/src/args-tokenizer.ts
+++ b/src/args-tokenizer.ts
@@ -15,6 +15,7 @@ export const tokenizeArgs = (
   let currentToken = "";
   let openningQuote: undefined | string;
   let escaped = false;
+  let quoted_arg = false;
   for (let index = 0; index < argsString.length; index += 1) {
     const char = argsString[index];
 
@@ -34,9 +35,10 @@ export const tokenizeArgs = (
     }
 
     if (openningQuote === undefined && spaceRegex.test(char)) {
-      if (currentToken.length > 0) {
+      if (currentToken.length > 0 || quoted_arg) {
         tokens.push(currentToken);
         currentToken = "";
+        quoted_arg = false;
       }
       continue;
     }
@@ -47,6 +49,7 @@ export const tokenizeArgs = (
         continue;
       }
       if (openningQuote === char) {
+        quoted_arg = true;
         openningQuote = undefined;
         continue;
       }


### PR DESCRIPTION
This resolves issue #6 by collecting arguments for quoted empty strings.